### PR TITLE
Improve lock handling in the textfile driver

### DIFF
--- a/WireQueueTextfile.module
+++ b/WireQueueTextfile.module
@@ -73,6 +73,23 @@ class WireQueueTextfile extends WireQueueStorage {
         return (touch($file) && wireChmod($file) ? true : false);
     }
 
+    /**
+     * Empties the queue file by truncating it.
+     */
+    public function purgeItems() {
+        $result = false;
+        if(!$this->ready2use()) return false;
+        if(false === ($file = $this->getFilename())) return false;
+        if(!$fp = @fopen($this->getFilename(), 'rb+')) return false;
+        if(flock($fp, LOCK_EX)) {
+            $result = ftruncate($fp, 0);
+            fflush($fp);
+            flock($fp, LOCK_UN);
+        }
+        fclose($fp);
+        return $result;
+    }
+
     public function addItem($arrayData) {
         if(!$this->_addItem()) return false;
         if(2 != $this->getState()) return false;

--- a/WireQueueTextfile.module
+++ b/WireQueueTextfile.module
@@ -138,7 +138,7 @@ class WireQueueTextfile extends WireQueueStorage {
         if(2 > $this->getState()) return 0;
         if(!$fp = @fopen($this->getFilename(), 'rb')) return false;
         $i = 0;
-        if(flock($fp, LOCK_EX)) {
+        if(flock($fp, LOCK_SH)) {
             while(!feof($fp)) {
                 if(fgets($fp)) $i++;
             }

--- a/WireQueueTextfile.module
+++ b/WireQueueTextfile.module
@@ -121,8 +121,11 @@ class WireQueueTextfile extends WireQueueStorage {
         if(2 > $this->getState()) return 0;
         if(!$fp = @fopen($this->getFilename(), 'rb')) return false;
         $i = 0;
-        while(!feof($fp)) {
-            if(fgets($fp)) $i++;
+        if(flock($fp, LOCK_EX)) {
+            while(!feof($fp)) {
+                if(fgets($fp)) $i++;
+            }
+            flock($fp, LOCK_UN);
         }
         fclose($fp);
         return $i;

--- a/WireQueueTextfile.module
+++ b/WireQueueTextfile.module
@@ -85,6 +85,7 @@ class WireQueueTextfile extends WireQueueStorage {
             fclose($fp);
             return $res == strlen($data);
         }
+        fclose($fp);
         return false;
     }
 

--- a/WireQueueTextfile.module
+++ b/WireQueueTextfile.module
@@ -90,6 +90,25 @@ class WireQueueTextfile extends WireQueueStorage {
         return $result;
     }
 
+    /**
+     * Tests if the queue has anything in it
+     *
+     * Faster than looking at the return value of itemCount() in conditional statements.
+     */
+    public function isEmpty() {
+        $result = false;
+        if(!$this->ready2use()) return true;
+        if(false === ($file = $this->getFilename())) return true;
+        if(!$fp = @fopen($this->getFilename(), 'rb')) return true;
+        if(flock($fp, LOCK_SH)) {
+            $stats = fstat($fp);
+            if (0 == $stats['size']) $result = true;
+            flock($fp, LOCK_UN);
+        }
+        fclose($fp);
+        return $result;
+    }
+
     public function addItem($arrayData) {
         if(!$this->_addItem()) return false;
         if(2 != $this->getState()) return false;


### PR DESCRIPTION
Hello Horst,

I've been using this for a while now and have noticed that, under heavy loads with large numbers of items in the queue, the itemCount() method is not accurate and can return any value between 0 and the real number of items in the queue. This fixes it.

In addition, I present the following methods for your consideration...
- _purgeItems()_ simply truncates the queue file, avoiding repeated calls to _getItem()_ and _itemCount()_.
- _isEmpty()_ provides a fast, constant time, way to see if a queue is empty - avoids _itemCount()'s_ reading of the file.

I've also included a small change to prevent file handle leakage should a lock fail to be acquired.

Thanks for looking!
Steve
